### PR TITLE
Default name set to md filename+'-cleaver.html'

### DIFF
--- a/lib/cleaver.js
+++ b/lib/cleaver.js
@@ -7,6 +7,8 @@ var mustache = require('mustache');
 var helper = require('./helper');
 
 function Cleaver(file) {
+  this.file = file
+
   if (!file) throw "!! Please specify a file to parse";
 
   // TODO: make these constants?
@@ -79,7 +81,8 @@ Cleaver.prototype._loadAssets = function () {
  */
 Cleaver.prototype._renderSlideshow = function () {
   var putControls = this.metadata.controls || (this.metadata.controls === undefined);
-  var outputLocation = this.metadata.output || 'cleaver.html';
+  var outputLocation = this.metadata.output || path.basename(this.file, '.md')+'-cleaver.html';
+  
   var title = this.metadata.title || 'Untitled';
 
   var slideData = {


### PR DESCRIPTION
To make it easy to find the generated .html file - if in a folder with many files - I suggest that default name (if not given) is the same as the original .md file plus -cleaver.html
