### PR TITLE
Add page URLs

### DIFF
--- a/resources/navigation.js
+++ b/resources/navigation.js
@@ -61,7 +61,6 @@ function setPageNumbers() {
   for (var i = 0; i < pages.length; ++i) {
     var page = pages[i];
     page.dataset.page = i;
-    console.log(page, i);
   }
 }
 


### PR DESCRIPTION
This PR adds a hash-URL to each page, which is updated upon each page switch. The proper page is then recalled upon a browser refresh. This allows the user, for example, to navigate away from the presentation and then return to the slide he was looking at.
