### PR TITLE
Fix navigation selection bug

### DIFF
--- a/resources/default.css
+++ b/resources/default.css
@@ -45,6 +45,14 @@ body {
   -webkit-border-top-right-radius: 20px;
   -moz-border-radius-topright: 20px;
   border-top-right-radius: 20px;
+
+  /* Fix selection bug */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 #controls #next {
@@ -53,6 +61,14 @@ body {
   -webkit-border-top-left-radius: 20px;
   -moz-border-radius-topleft: 20px;
   border-top-left-radius: 20px;
+  
+  /* Fix selection bug */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .slide h1 {


### PR DESCRIPTION
When clicking on the navigation buttons several times (e.g. double clicking) they get selected, which is annoying.
This css trick (from: http://stackoverflow.com/questions/826782/css-rule-to-disable-text-selection-highlighting) should fix it.
