### PR TITLE
Added metadata 'encoding' to define html document charset

### DIFF
--- a/examples/basic.md
+++ b/examples/basic.md
@@ -1,4 +1,5 @@
 title: Basic Example
+encoding: utf-8
 author:
   name: "Jordan Scales"
   twitter: "@jdan"
@@ -27,3 +28,25 @@ This will be in a separate paragraph
 * Item gamma
 
 No need for multiple templates!
+
+--
+
+### Unicode
+
+* 林花謝了春紅 太匆匆
+* 胭脂淚 留人醉 幾時重
+* Matching Pairs «»‹› “”‘’「」〈〉《》〔〕
+* Greek αβγδ εζηθ ικλμ νξοπ ρςτυ φχψω
+* currency  ¤ $ ¢ € ₠ £ ¥
+
+--
+
+### Images
+
+* Insert images through markup or html tag
+
+<img src="http://whatismarkdown.com/workspace/img/logo.gif" alt="Drawing" style="width: 150px;"/>
+
+    ![markdown-logo](logo.gif)
+    <img src="logo.gif" />
+

--- a/lib/cleaver.js
+++ b/lib/cleaver.js
@@ -67,6 +67,8 @@ Cleaver.prototype._parseDocument = function () {
             self.external.loaded.style = data;
           })
       }
+
+  
     });
 }
 
@@ -91,10 +93,14 @@ Cleaver.prototype._renderSlideshow = function () {
   var outputLocation = this.metadata.output || path.basename(this.file, '.md') + '-cleaver.html';
 
   var title = this.metadata.title || 'Untitled';
+  //Set document encoding through metadata 'encoding'; 
+  //for example: encoding: utf-8 leads to tag <meta charset="utf-8"> inserted into the html
+  var encoding = (this.metadata.encoding) ? '<meta charset="' + this.metadata.encoding + '">' : '';
 
   var slideData = {
     slides: this.slides,
     title: title,
+    encoding: encoding,
     controls: putControls,
     style: this.resources.loaded.style,
     externalStyle: this.external.loaded.style,

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -1,5 +1,6 @@
 <html>
 <head>
+  {{{encoding}}}
   <title>{{title}}</title>
   <style type="text/css">
     {{{style}}}


### PR DESCRIPTION
Cleaver in its current HEAD doesn´t facilitate unicode text, for example German, Dutch, Spanish in UTF-8, symbols etc. I´ve added the medata parameter 'encoding' which allows to specify the charset 
