### PR TITLE
fixed path handling for windows

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -10,7 +10,7 @@ var normalizePath;
  * Root directory so that asset loaders know where to look
  * @constant {string}
  */
-var ROOT_DIR = path.normalize(__dirname + '/../');
+var ROOT_DIR = path.resolve(__dirname, '..');
 
 
 /**
@@ -70,7 +70,7 @@ function load(map, external) {
     if (!map[key]) continue;
 
     filename = map[key];
-    if (!external) filename = ROOT_DIR + filename;
+    if (!external) filename = path.resolve(ROOT_DIR, filename);
 
     promises.push(loadSingle(filename)
       .then((function (_key) {
@@ -243,8 +243,9 @@ module.exports = function (inputPath) {
   normalizePath = function (pathname) {
     if (pathname[0] == '~') pathname = pathname.replace('~', getUserHome());
     if (pathname[0] == '/') return pathname;
+    if (path.resolve(pathname) == pathname) return pathname;
 
-    return path.normalize(path.dirname(inputPath) + '/' + pathname);
+    return path.resolve(path.dirname(inputPath), pathname);
   }
 
   return {


### PR DESCRIPTION
I updated from my older cleaver 0.4.x to 0.5.1 on my windows workstation but afterwards cleaver didn't work because of the way paths get concatenated. 

While fixing that I found 2 other places that need a small change to work on windows.
