### PR TITLE
Add init command handling

### DIFF
--- a/bin/cleaver
+++ b/bin/cleaver
@@ -2,7 +2,7 @@
 
 var path = require('path');
 var fs = require('fs');
-var Cleaver = require(path.join(__dirname,'../lib/cleaver.js'));
+var Cleaver = require(path.resolve(__dirname,'../lib/cleaver'));
 var program = require('commander');
 
 program
@@ -13,7 +13,7 @@ program
   .command('watch')
   .description('Watch for changes on markdown file')
   .action(function(){
-    file = program.args[0];
+    var file = program.args[0];
     new Cleaver(file).run();
 
     console.log('Watching for changes on ' + file + '. Ctrl-C to abort.');
@@ -23,13 +23,22 @@ program
     });
   });
 
+program
+  .command('init')
+  .description('Boilerplate your presentation')
+  .action(function(){
+    require('../lib/wizard').init(program);
+  });
+program
+  .command('*')
+  .action(function(env){
+    var file = program.args[0];
+    var cleaver = new Cleaver(file);
+    cleaver.run();
+  });
 program.parse(process.argv);
 
 if (!program.args.length) {
   program.help();
-} else {
-  var file = program.args[0];
-  var cleaver = new Cleaver(file);
-  cleaver.run();
 }
 

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -1,0 +1,125 @@
+/* global program */
+var fs = require('fs');
+var Q = require('q');
+var exec = require('child_process').exec;
+var prompt = require('prompt');
+module.exports = {
+  init: function (program) {
+    global.program = program;
+    prompt.message = '>>';
+    prompt.delimiter = ':'.green;
+    console.log("This utility will walk you through creating your very own presentation file.");
+    console.log("Press ^C at any time to quit.");
+    getUsername().then(getPrompt).then(checkForFile).then(writeToFile).catch(console.log);
+  }
+};
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function getUsername() {
+  var deferred = Q.defer();
+  try {
+    exec('git config -l | grep user.name', function (err, str) {
+      // we get back 'user.name=%username%'
+      var args = str.replace(/\n/, '').split('=');
+      deferred.resolve(args[1]);
+    });
+  } catch (e) {
+    // fallback to getting username based on home directory name
+    var path = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+    deferred.resolve(path.split(/\/\\/).slice(-1)[0]);
+  }
+  return deferred.promise;
+}
+
+function getPrompt(username) {
+  var deferred = Q.defer();
+  var probableTitle = (program.args[0].constructor.name !== 'Command') ? program.args[0] : process.cwd().split('/').slice(-1)[0];
+  var promptSeries = [
+    {
+      name: 'input',
+      description: 'Input markdown file',
+      type: 'string',
+      default: probableTitle + '.md',
+      required: true
+    },
+    {
+      name: 'title',
+      description: 'Presentation title',
+      type: 'string',
+      default: capitalize(probableTitle),
+      required: true
+    },
+    {
+      name: 'author.name',
+      description: 'Your name',
+      type: 'string',
+      default: username,
+      required: false
+    },
+    {
+      name: 'author.twitter',
+      description: 'Your twitter handler',
+      type: 'string',
+      default: username,
+      required: false
+    },
+    {
+      name: 'output',
+      description: 'Presentation output filename',
+      type: 'string',
+      default: probableTitle + '.html',
+      required: true
+    }
+  ];
+  prompt.start();
+  prompt.get(promptSeries, function (err, result) {
+    if (err) {return deferred.reject(err); }
+    deferred.resolve(result);
+  });
+  return deferred.promise;
+}
+
+function checkForFile(result) {
+  var deferred = Q.defer();
+  var inc = result.input;
+  var confirmation = {
+      name: 'confirm',
+      pattern: /^(y|yes|no|n)$/i,                  // Regular expression that input must be valid against.
+      message: 'Y/Yes/No/N only',
+      description: 'File '+inc.green+' already exist. Overwrite?'.grey,
+      default: 'Yes',
+      required: true
+    };
+  if (!fs.existsSync(process.cwd() + '/' + inc)) {
+    deferred.resolve(result);
+  } else {
+    prompt.start();
+    prompt.get(confirmation, function (err, confirmation) {
+      if (confirmation.confirm.match(/(no|n)/i)) {
+        deferred.reject('Aborting like right now!');
+      } else {
+        deferred.resolve(result);
+      }
+    });
+  }
+  return deferred.promise;
+}
+
+function writeToFile(result) {
+  console.log('writeFile result ', result);
+  var presentation = result.input;
+  var message = "title: {title}\nauthor:\n  name: {name}\n  twitter: {twitter}\noutput: {output}"
+    .replace('{title}', result.title)
+    .replace('{name}', result['author.name'])
+    .replace('{twitter}', result['author.twitter'])
+    .replace('{output}', result.output);
+  fs.writeFile(presentation, message, function (err) {
+    if (err) { return console.log('Oh no, sorry, there was an ',err.message,' error'); }
+    console.log('Rise and shine! Be sure to run cleaver watch ', presentation,' to start hacking rihgt away');
+  });
+  console.log('Inited empty presentation at '+ presentation.green +' containing:');
+  console.log(message);
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "js-yaml": "2.1.0",
     "highlight.js": "~7.3.0",
     "marked": "~0.2.9",
-    "commander": "~2.1.0"
+    "commander": "~2.1.0",
+    "prompt": "~0.2.12"
   },
   "devDependencies": {
     "jshint": "~2.3.0"


### PR DESCRIPTION
What this PR does:
+ adds catchall task (had trouble trying to run `cleaver init` with previous version of code)
+ adds cleaver init functionality:
User is prompted for presentation's title, his name, twitter handler, output file.
`cleaver init lolz` will be assuming title of Lolz, lolz.md as input file and lolz.html as output file.
Username is either git username or last part of ~ directory name
Twitter handler default is username
Output files default is downcased title + '.html'

Needs: 
+ proper testing on another environment,
+ omission (maybe?) for empty properties (so, if I make something empty, it doesn't appear in output file) 
