### PR TITLE
just prototype

### DIFF
--- a/examples/basic.md
+++ b/examples/basic.md
@@ -3,7 +3,9 @@ author:
   name: Jordan Scales
   twitter: jdan
   url: http://jordanscales.com
-output: basic.html
+outlet: '>>'
+iterator: '<<'
+output: index.html
 
 --
 
@@ -60,4 +62,22 @@ var func = function (arg1) {
 console.log(func(1)(2)); // result is three
 ```
 
+--
+
+### Speaking
+When points are appearing one by one is
+>> so
+>> more
+>> effective
+>> not really.
+
+--
+### Giving talk
+
+You might want to
+<< give single reason
+<< show same caption for figures
+<< reuse some stuff on slide
+
+--
 And here is some `inline code` to check out.

--- a/lib/cleaver.js
+++ b/lib/cleaver.js
@@ -66,11 +66,18 @@ Cleaver.prototype.loadDocument = function () {
  */
 Cleaver.prototype.renderSlides = function () {
   var self = this;
+  var copy = []
   var slices = this.slice(self.external.loaded.document);
   this.metadata = yaml.safeLoad(slices[0]) || {};
-
-  for (var i = 1; i < slices.length; i++) {
-    this.slides.push(this.renderSlide(slices[i]));
+  if (!this.metadata.outlet) { this.metadata.outlet = '>>'; }
+  if (!this.metadata.iterator) {this.metadata.iterator = '<<'; }
+  var toPush;
+  slices.forEach(function(slice, index){
+    toPush = index ? self.preprocess(slice): [slice];
+    [].push.apply(copy, toPush)
+  })
+  for (var i = 1; i < copy.length; i++) {
+    this.slides.push(this.renderSlide(copy[i]));
   }
 
   // insert an author slide (if necessary) at the end
@@ -208,9 +215,42 @@ Cleaver.prototype.renderSlideshow = function () {
  * @return {string} The formatted slide
  */
 Cleaver.prototype.renderSlide = function (content) {
+  if (typeof content == 'object') {
+    console.log('Content is ', content)
+  }
   return marked(content);
 };
-
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}
+Cleaver.prototype.preprocess = function (slide) {
+  var slides = [];
+  var outRegexp = RegExp(escapeRegExp(this.metadata.outlet, 'mg'));
+  var iteRegexp = RegExp(escapeRegExp(this.metadata.iterator, 'mg'));
+  if (!(slide.match(outRegexp) || slide.match(iteRegexp))) { return [slide]; }
+  var lines = slide.split('\n')
+  outletted = lines.filter(function (line) {
+    return line.match(outRegexp)
+  })
+  iterated =  lines.filter(function (line) {
+    return line.match(iteRegexp)
+  })
+  if (outletted.length) {
+    outletted.forEach(function (c, indexUpToInclude) {
+      slides.push(lines.filter(function (line, index) {
+        return outletted.indexOf(line) == -1 || outletted.indexOf(line) <= indexUpToInclude
+      }).join('\n'))
+    })
+  }
+  if (iterated.length) {
+    iterated.forEach(function (currentIncluded, i) {
+      slides.push(lines.filter(function (line) {
+        return iterated.indexOf(line) == -1 || line == currentIncluded
+      }).join('\n'))
+    })
+  }
+  return slides;
+}
 
 /**
  * Renders the author slide.


### PR DESCRIPTION
This isn't intended to be merged, just to get on the same page on preprocessing stuff. Here's my attempt to implement outletting & iterating over stuff on slide with customizeble delimiters. 
See small [demo](http://sudodoki.github.io/cleaver/#5). 
There's also a matter to address on how to apply hooks to this kind of things (maybe, separate templates for outletted/iterated parts should be used or some callback/API provided to be able to modify text before it's getting into generated presenation - I mostly see this as a handy thing for themes).
