### PR TITLE
change file to load options from

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -123,7 +123,7 @@ function loadTheme(source, ctx) {
   }
 
   promises = [
-    loadSettings(source + 'settings.json', ctx),
+    loadSettings(source + 'options.json', ctx),
     populateSingle(source + 'style.css', ctx.external, 'style', true),
     populateSingle(source + 'template.mustache', ctx.templates, 'slides', true),
     populateSingle(source + 'layout.mustache', ctx.templates, 'layout', true),


### PR DESCRIPTION
Since throughout documentation it says to put override flag into `options.json` it was fun finding out the reason it didn't override scripts :smile_cat: 
