### PR TITLE
Use default path if output metadata is not given.

### DIFF
--- a/bin/cleaver
+++ b/bin/cleaver
@@ -16,7 +16,7 @@ function createAndSave(file) {
 
     promise
       .then(function (product) {
-        var outputFile = presentation.metadata.output;
+        var outputFile = presentation.metadata.output || path.basename(file, '.md') + '-cleaver.html';
         fs.writeFile(outputFile, product);
       })
       .fail(function (err) {


### PR DESCRIPTION
Maybe this feature is lost in jdan/cleaver@0b8ff3d0fdea804e597d4a36e31b7f9d908290a7
