### PR TITLE
Debugging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ cleaver watch path/to/something-changing.md
 # Rebuilding: Thu Nov 07 2013 00:16:09 GMT-0500 (EST)
 ```
 
+Use the `--debug` flag to display debug information:
+
+```bash
+$ cleaver --debug examples/basic.md
+  cleaver loaded input document +0ms
+  helper read /Users/jordan/Projects/cleaver/templates/layout.mustache +0ms
+  helper read /Users/jordan/Projects/cleaver/templates/author.mustache +0ms
+  helper read /Users/jordan/Projects/cleaver/templates/default.mustache +0ms
+  cleaver loaded templates +3ms
+  cleaver parsed metadata +4ms
+  helper read /Users/jordan/Projects/cleaver/resources/default.css +13ms
+  helper read /Users/jordan/Projects/cleaver/resources/github.css +0ms
+  helper read /Users/jordan/Projects/cleaver/resources/script.js +0ms
+  cleaver loaded static assets +9ms
+  cleaver rendered slides +1ms
+  cleaver rendered presentation +1ms
+```
+
 ## More Info
 
 **Cleaver** is a one-stop shop for generating HTML presentations in

--- a/bin/cleaver
+++ b/bin/cleaver
@@ -2,8 +2,8 @@
 
 var path = require('path');
 var fs = require('fs');
-var Cleaver = require(path.join(__dirname,'../lib/cleaver.js'));
 var program = require('commander');
+var Cleaver;
 
 /**
  * Helper function to use the cleaver API to create and save a new
@@ -21,6 +21,9 @@ function createAndSave(file) {
       })
       .fail(function (err) {
         process.stderr.write('!! ' + err.message + '\n');
+        if (program.debug) {
+          process.stderr.write(err.stack);
+        }
         process.exit(1);
       });
   });
@@ -33,7 +36,7 @@ program
 program
   .command('watch')
   .description('Watch for changes on markdown file')
-  .action(function(){
+  .action(function () {
     var file = program.args[0];
     createAndSave(file);
 
@@ -44,11 +47,28 @@ program
     });
   });
 
+program
+  .option('--debug', 'Enable debug output');
+
 program.parse(process.argv);
 
 if (!program.args.length) {
   program.help();
 } else {
+  /**
+   * Enable debugging
+   *
+   * For finer-tuned debugging you can ignore the --debug flag and
+   * instead use the DEBUG environment variable that the `debug` module
+   * reads automatically.
+   *
+   * $ DEBUG=[cleaver,helper] cleaver path/to/presentation.md
+   */
+  if (program.debug) {
+    process.env.DEBUG = '*';
+  }
+
+  /* Load cleaver with the new ENV for debugging */
+  Cleaver = require(path.join(__dirname,'../lib/cleaver.js'));
   createAndSave(program.args[0]);
 }
-

--- a/lib/cleaver.js
+++ b/lib/cleaver.js
@@ -1,4 +1,5 @@
 var Q = require('q');
+var debug = require('debug')('cleaver');
 var path = require('path');
 var marked = require('marked');
 var hljs = require('highlight.js');
@@ -56,8 +57,12 @@ function Cleaver(document, includePath) {
  */
 Cleaver.prototype.loadDocument = function () {
   return Q.all([
-    helper.load(this.external, { external: true }),
-    helper.load(this.templates)
+    helper.load(this.external, { external: true }).then(function () {
+      debug('loaded input document');
+    }),
+    helper.load(this.templates).then(function () {
+      debug('loaded templates');
+    })
   ]);
 };
 
@@ -72,6 +77,7 @@ Cleaver.prototype.renderSlides = function () {
   var i;
 
   this.metadata = yaml.safeLoad(slices[0].content) || {};
+  debug('parsed metadata');
 
   for (i = 1; i < slices.length; i++) {
     this.slides.push({
@@ -111,17 +117,26 @@ Cleaver.prototype.populateResources = function () {
 
   // maybe load an external stylesheet
   if (this.metadata.style) {
-    promises.push(helper.populateSingle(this.metadata.style, this.external, 'style'));
+    promises.push(helper.populateSingle(this.metadata.style, this.external, 'style')
+      .then(function () {
+        debug('loaded user stylesheet');
+      }));
   }
 
   // maybe load an external template
   if (this.metadata.template) {
-    promises.push(helper.populateSingle(this.metadata.template, this.templates, 'slides'));
+    promises.push(helper.populateSingle(this.metadata.template, this.templates, 'slides')
+      .then(function () {
+        debug('loaded user template');
+      }));
   }
 
   // maybe load an external layout
   if (this.metadata.layout) {
-    promises.push(helper.populateSingle(this.metadata.layout, this.templates, 'layout'));
+    promises.push(helper.populateSingle(this.metadata.layout, this.templates, 'layout')
+      .then(function () {
+        debug('loaded user layout');
+      }));
   }
 
   return Q.all(promises);
@@ -136,7 +151,9 @@ Cleaver.prototype.populateResources = function () {
 Cleaver.prototype.populateThemeResources = function () {
   // maybe load a theme
   if (this.metadata.theme) {
-    return helper.loadTheme(this.metadata.theme, this);
+    return helper.loadTheme(this.metadata.theme, this).then(function () {
+      debug('loaded theme');
+    });
   }
 };
 
@@ -150,7 +167,9 @@ Cleaver.prototype.populateThemeResources = function () {
 Cleaver.prototype.loadStaticAssets = function () {
   return Q.all([
     helper.load(this.resources)
-  ]);
+  ]).then(function () {
+    debug('loaded static assets');
+  });
 };
 
 
@@ -162,7 +181,7 @@ Cleaver.prototype.loadStaticAssets = function () {
 Cleaver.prototype.renderSlideshow = function () {
   var putControls = this.metadata.controls || (this.metadata.controls === undefined);
   var putProgress = this.metadata.progress || (this.metadata.progress === undefined);
-  var style, script;
+  var style, script, output;
 
   // Render the slides in a template (maybe as specified by the user)
   var slideshow = mustache.render(this.templates.loaded.slides, {
@@ -170,6 +189,8 @@ Cleaver.prototype.renderSlideshow = function () {
     controls: putControls,
     progress: putProgress
   });
+
+  debug('rendered slides');
 
   // TODO: handle defaults gracefully
   var title = this.metadata.title || 'Untitled';
@@ -206,7 +227,11 @@ Cleaver.prototype.renderSlideshow = function () {
   };
 
   /* Return the rendered slideshow */
-  return mustache.render(this.templates.loaded.layout, layoutData);
+  output = mustache.render(this.templates.loaded.layout, layoutData);
+
+  debug('rendered presentation');
+
+  return output;
 };
 
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,4 +1,5 @@
 var Q = require('q');
+var debug = require('debug')('helper');
 var http = require('http');
 var https = require('https');
 var fs = require('fs');
@@ -16,16 +17,15 @@ var ROOT_DIR = path.resolve(__dirname, '..');
 /**
  * Loads a single static asset from either a filename or URL. Returns a promise.
  * @param {string} source The source document to load
- * @param {!Boolean} failsafe Option to fail gracefully, without raising errors
  * @return {Promise.<string>} The file contents
  */
-function loadSingle(source, failsafe) {
+function loadSingle(source) {
   var promise;
 
   if (source.match(/^https?:\/\//)) {
-    promise = httpGetPromise(source, failsafe);
+    promise = httpGetPromise(source);
   } else {
-    promise = readFilePromise(normalizePath(source), failsafe);
+    promise = readFilePromise(normalizePath(source));
   }
 
   return promise;
@@ -42,11 +42,10 @@ function loadSingle(source, failsafe) {
  * @param {string} filename The name and location of the file to load
  * @param {Object} destination The destination map to store the loaded data
  * @param {string} key The key to use for storing the loaded data in destination
- * @param {!Boolean} failsafe Option to fail gracefully, without raising errors
  * @return {Promise}
  */
-function populateSingle(filename, destination, key, failsafe) {
-  return loadSingle(filename, failsafe)
+function populateSingle(filename, destination, key) {
+  return loadSingle(filename)
     .then(function (data) {
       if (data) {
         /**
@@ -139,10 +138,10 @@ function loadTheme(source, ctx) {
 
   promises = [
     loadSettings(source + 'settings.json', ctx),
-    populateSingle(source + 'style.css', ctx.external, 'style', true),
-    populateSingle(source + 'template.mustache', ctx.templates, 'slides', true),
-    populateSingle(source + 'layout.mustache', ctx.templates, 'layout', true),
-    populateSingle(source + 'script.js', ctx.external, 'script', true)
+    populateSingle(source + 'style.css', ctx.external, 'style'),
+    populateSingle(source + 'template.mustache', ctx.templates, 'slides'),
+    populateSingle(source + 'layout.mustache', ctx.templates, 'layout'),
+    populateSingle(source + 'script.js', ctx.external, 'script')
   ];
 
   return Q.all(promises);
@@ -157,7 +156,7 @@ function loadTheme(source, ctx) {
  * @return {Promise}
  */
 function loadSettings(source, ctx) {
-  return loadSingle(source, true).then(function (data) {
+  return loadSingle(source).then(function (data) {
     if (data) {
       data = JSON.parse(data);
       ctx.override = data.override;
@@ -169,53 +168,49 @@ function loadSettings(source, ctx) {
 /**
  * Promise to load a files contents
  * @param {string} filename The file to load
- * @param {!Boolean} failsafe Option to fail gracefully, without raising errors
  * @return {Promise.<string>} The file's contents
  */
-function readFilePromise(filename, failsafe) {
+function readFilePromise(filename) {
   var deferred;
 
-  if (!failsafe) {
-    return Q.nfcall(fs.readFile, filename, 'utf-8');
-  } else {
-    deferred = Q.defer();
+  deferred = Q.defer();
 
-    fs.readFile(filename, 'utf-8', function (err, contents) {
+  fs.readFile(filename, 'utf-8', function (err, contents) {
+    if (err) {
+      debug(err + ' ' + filename);
+    } else {
+      debug('read ' + filename);
       deferred.resolve(contents);
-    });
+    }
+  });
 
-    return deferred.promise;
-  }
+  return deferred.promise;
 }
 
 
 /**
  * Promise to perform a get request and return the result
  * @param {string} url The url to request
- * @param {!Boolean} failsafe Option to fail gracefully, without raising errors
  * @return {Promise.<string>} The body of the response
  */
-function httpGetPromise(url, failsafe) {
+function httpGetPromise(url) {
   var deferred = Q.defer(), get;
 
   var cb = function (res) {
     var data = '';
-
-    if (res.statusCode !== 200) {
-      if (failsafe) {
-        deferred.resolve();
-      } else {
-        deferred.reject(new Error(
-          'The url (' + url + ') returned with status ' + res.statusCode));
-      }
-    }
 
     res.on('data', function (chunk) {
       data += chunk;
     });
 
     res.on('end', function () {
-      deferred.resolve(data);
+      if (res.statusCode !== 200) {
+        debug(res.statusCode + ': ' + url);
+        deferred.resolve();
+      } else {
+        debug('fetched ' + url);
+        deferred.resolve(data);
+      }
     });
   };
 
@@ -226,12 +221,8 @@ function httpGetPromise(url, failsafe) {
   }
 
   get.on('error', function (err) {
-    if (failsafe) {
-      deferred.resolve();
-    } else {
-      deferred.reject(new Error(
-        'The url (' + url + ') caused an error'));
-    }
+    deferred.resolve();
+    debug(err + ': ' + url);
   });
 
   return deferred.promise;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleaver",
   "preferGlobal": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": "Jordan Scales <scalesjordan@gmail.com>",
   "description": "30-second slideshows for hackers",
   "keywords": [
@@ -28,6 +28,7 @@
     "commander": "~2.1.0"
   },
   "devDependencies": {
+    "debug": "~0.8.0",
     "jshint": "~2.3.0"
   },
   "scripts": {


### PR DESCRIPTION
These changes add debug support for cleaver. Too often have I run into issues with loading themes (or any resources for that matter), where I need to crawl down the rabbit hole to figure out what's failing. I've brought in [TJ](http://github.com/visionmedia)'s [debug](https://github.com/visionmedia/debug) module to help with this task. 

The result is really nice!

![screen shot 2014-04-26 at 12 34 44 am](https://cloud.githubusercontent.com/assets/287268/2807875/2421c988-ccfc-11e3-841b-ff70e3b39db4.png)

This flag will also enable full stack traces when errors crop up.

To use it yourself, just specify the `--debug` flag when running the cleaver command. I'll also bump the version here to push out a new patch release.
