### PR TITLE
Include local images with base64 encoded data uri

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -3,7 +3,7 @@
 Quick links: [title](#title), [author](#author), [theme](#theme),
 [style](#style), [output](#output), [controls](#controls),
 [progress](#progress), [encoding](#encoding), [template](#template),
-[layout](#layout)
+[layout](#layout), [base64](#base64)
 
 Cleaver supports several basic options for adding a bit of customization to
 your presentations. These options are placed at the top of your document, in
@@ -100,3 +100,16 @@ URL or absolute/relative path to a mustache template used to render the entire
 slideshow. See
 [layout.mustache](https://github.com/jdan/cleaver/blob/master/templates/layout.mustache)
 for inspiration.
+
+### base64
+
+Allow the inclusion of resources as data uri, base64 encoded
+
+For the moment, the only asset supported are local images (i.e. images present on the machine where cleaver is run, with a path relative to the md file) .
+
+This is achieved with the following field:
+* localImages (default to false)
+
+The option is therefore:
+    base64
+        localImages: true

--- a/docs/options.md
+++ b/docs/options.md
@@ -111,5 +111,6 @@ This is achieved with the following field:
 * localImages (default to false)
 
 The option is therefore:
-    base64
-        localImages: true
+
+    base64:
+      localImages: true

--- a/lib/cleaver.js
+++ b/lib/cleaver.js
@@ -41,11 +41,27 @@ function Cleaver(document, includePath) {
   this.slides = [];
   this.override = false;
 
+  var renderer = new marked.Renderer();
+  var cleaver = this;
+  renderer.image = function(href, title, text) {
+    if(cleaver.metadata.base64 && cleaver.metadata.base64.localImages) {
+      // For the moment, we only handle local images
+      if(!href.match(/https?\:\/\//)) {
+        var base64content = helper.getBase64FileContent(href);
+        if(base64content) {
+          return marked.Renderer.prototype.image.call(this, helper.getDataUriBase(href) + base64content, title, text);
+        }
+      }
+    }
+    return marked.Renderer.prototype.image.call(this, href, title, text);// oriImage(href, title, text); // '<a href="' + href + '" alt="' + text + "' />";
+  };
+
   marked.setOptions({
     gfm: true,
     highlight: function (code, lang) {
       return (lang) ? hljs.highlight(lang, code).value : code;
-    }
+    },
+    renderer: renderer
   });
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -187,7 +187,32 @@ function readFilePromise(filename) {
   return deferred.promise;
 }
 
+function getBase64FileContent(filename) {
+  var normFilename = normalizePath(filename);
+  return fs.existsSync(normFilename) ? fs.readFileSync(normFilename).toString('base64') : null;
+}
 
+function getDataUriBase(filename) {
+  var type = "";
+  var filenameSplit = filename.toLowerCase().split('.');
+  switch(filenameSplit[filenameSplit.length -1]) {
+    case 'jpg':
+    case 'jpeg':
+      type = 'jpeg';
+      break;
+    case 'png':
+      type = 'png';
+      break;
+    case 'gif':
+      type = 'gif';
+      break;
+    default:
+      // Is it better to put something wrong or nothing ?
+      type = 'jpeg';
+      break;
+  }
+  return "data:image/" + type + ";base64,";
+}
 /**
  * Promise to perform a get request and return the result
  * @param {string} url The url to request
@@ -259,6 +284,8 @@ module.exports = function (inputPath) {
     loadSingle: loadSingle,
     populateSingle: populateSingle,
     load: load,
-    loadTheme: loadTheme
+    loadTheme: loadTheme,
+    getBase64FileContent: getBase64FileContent,
+    getDataUriBase: getDataUriBase
   };
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "q": "0.9.6",
     "js-yaml": "2.1.0",
     "highlight.js": "~7.3.0",
-    "marked": "~0.2.9",
+    "marked": "~0.3.2",
     "commander": "~2.1.0",
     "debug": "~0.8.0"
   },


### PR DESCRIPTION
In order to make the generated presentation even more self-contained, this PR allows the user to specify an option to encode images present locally in base64 format and inserted as data uris in the presentation instead of a normal src reference which forces to always have the images next to the html presentation.

This works, for the moment, only for images that are on the machine where cleaver is run, and specified with a relative path.