### PR TITLE
Add support in author.mustache for github attribute

### DIFF
--- a/templates/author.mustache
+++ b/templates/author.mustache
@@ -5,6 +5,11 @@
       <a href="http://twitter.com/{{{twitter}}}">{{{twitter}}}</a>
     </h3>
   {{/twitter}}
+  {{#github}}
+    <h3 class="github">
+      <a href="https://github.com/{{{github}}}">{{{github}}}</a>
+    </h3>
+  {{/github}}
   {{#weibo}}
     <h3 class="weibo">
       <a href="http://weibo.com/{{{weibo}}}">{{{weibo}}}</a>


### PR DESCRIPTION
Seems reasonable to support a Github handle w/ link since cleaver seems to be aimed at devs :)
