### PR TITLE
Suggestion: Add a way to set slide cover images

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var marked = require('marked');
 var hljs = require('highlight.js');
 var yaml = require('js-yaml');
 var mustache = require('mustache');
+var _ = require('lodash');
 
 var clone = require('./clone');
 var helper;
@@ -43,7 +44,8 @@ function Cleaver(document, options, includePath) {
   this.templates = {
     layout: 'templates/layout.mustache',
     author: 'templates/author.mustache',
-    slides: 'templates/default.mustache'
+    slides: 'templates/default.mustache',
+    bkgImages: 'templates/bkgImages.mustache'
   };
 
   this.resources = {
@@ -215,6 +217,21 @@ Cleaver.prototype.renderSlideshow = function () {
     progress: putProgress
   });
 
+  // Render background images
+  // Match <!-- background: http://example.com/batman.jpg -->
+  var bkgMatcher = /<!--\s*background:\s*(.+)\s*-->/g;
+  bkgImages = [];
+  _.each(this.slides, function(slide, num) {
+    var match = bkgMatcher.exec(slide.content);
+    if (match) {
+      bkgImages.push({
+        slideId: 'slide-' + (num + 1),  // zero- to one-indexing
+        bkgImage: match[1]  // Extract the image URL
+      });
+    }
+  });
+  bkgImageStyle = mustache.render(this.templates.loaded.bkgImages, {bkgImages: bkgImages})
+
   debug('rendered slides');
 
   // TODO: handle defaults gracefully
@@ -227,6 +244,7 @@ Cleaver.prototype.renderSlideshow = function () {
     style = [
       this.resources.loaded.style,
       this.resources.loaded.githubStyle,
+      bkgImageStyle,
       // External styles are represented with an array
       this.external.loaded.style && this.external.loaded.style.join('\n')
     ].join('\n');

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,7 +219,9 @@ Cleaver.prototype.renderSlideshow = function () {
 
   // Render background images
   // Match <!-- background: http://example.com/batman.jpg -->
-  var bkgMatcher = /<!--\s*background:\s*(.+)\s*-->/g;
+  // Do NOT make this a global (/g) regex:
+  // http://stackoverflow.com/a/3811949/254187
+  var bkgMatcher = /<!--\s*background:\s*(.+)\s*-->/;
   bkgImages = [];
   _.each(this.slides, function(slide, num) {
     var match = bkgMatcher.exec(slide.content);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "^2.1.1",
     "highlight.js": "~7.3.0",
     "js-yaml": "2.1.0",
+    "lodash": "^3.9.3",
     "marked": "~0.2.9",
     "mustache": "0.7.0",
     "q": "0.9.6"

--- a/templates/bkgImages.mustache
+++ b/templates/bkgImages.mustache
@@ -1,0 +1,15 @@
+{{#bkgImages}}
+  #{{slideId}} {
+    background: url({{{bkgImage}}});
+  }
+{{/bkgImages}}
+
+{{#bkgImages}}
+  #{{slideId}},
+{{/bkgImages}}
+#dummyIdToAvoidTrailingComma {
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+}


### PR DESCRIPTION
Hey @jdan, thanks for writing Cleaver!

This PR is a suggestion more than a request to merge code. I wanted to add background cover images to some of my slides, so I did.

To add a cover image to a slide, just add `<!-- background: http://example.com/batmobile.jpg -->` to the body of any slide. It will generate the background CSS to set the background image for each individual slide. It will set the CSS background size for all slides to `cover`.

Let me know what you think. I'd be happy to re-implement this in a different way if you like the idea but not the code.