### PR TITLE
Enable live reload when using cleaver watch

### DIFF
--- a/bin/cleaver
+++ b/bin/cleaver
@@ -3,6 +3,7 @@
 var path = require('path');
 var fs = require('fs');
 var program = require('commander');
+var tinylr = require('tiny-lr');
 var pluck = require('../lib/pluck');
 var Cleaver = require('../');
 
@@ -69,10 +70,17 @@ program
     var options = getOptions();
     createAndSave([file], options);
 
+    var port = 35729;
+    tinylr().listen(port, function() {
+      console.log('Live reload listening on %s', port);
+    });
+
     console.log('Watching for changes on ' + file + '. Ctrl-C to abort.');
     fs.watchFile(file, { persistent: true, interval: 100 }, function () {
       console.log('Rebuilding: ' + new Date());
       createAndSave([file], options);
+      console.log('Notifying live reload.');
+      tinylr.changed(file);
     });
 
     // Also watch on stylesheet if included via command prompt
@@ -81,6 +89,8 @@ program
       fs.watchFile(options.style, { persistent: true,  interval: 100 }, function () {
         console.log('Rebuilding: ' + new Date());
         createAndSave([file], options);
+        console.log('Notifying live reload.');
+        tinylr.changed(file);
       });
     }
   });

--- a/bin/cleaver
+++ b/bin/cleaver
@@ -13,10 +13,6 @@ var Cleaver = require('../');
  * presentation
  */
 function createAndSave(files, options, done) {
-  if (!done) {
-    done = function(){};
-  }
-
   files.forEach(function (file) {
     fs.readFile(file, 'utf-8', function (err, contents) {
       if (err) {
@@ -28,8 +24,7 @@ function createAndSave(files, options, done) {
       presentation.run()
         .then(function (product) {
           var outputFile = presentation.options.output || path.basename(file, '.md') + '-cleaver.html';
-          fs.writeFile(outputFile, product);
-          done();
+          fs.writeFile(outputFile, product, done);
         })
         .fail(function (err) {
           process.stderr.write('!! ' + err.message + '\n');
@@ -84,9 +79,9 @@ program
     console.log('Watching for changes on ' + file + '. Ctrl-C to abort.');
     fs.watchFile(file, { persistent: true, interval: 100 }, function () {
       console.log('Rebuilding: ' + new Date());
-      createAndSave([file], options);
-      console.log('Notifying live reload.');
-      tinylr.changed(file);
+      createAndSave([file], options, function() {
+        tinylr.changed(file);
+      });
     });
 
     // Also watch on stylesheet if included via command prompt
@@ -94,9 +89,9 @@ program
       console.log('Also watching for changes on ' + options.style);
       fs.watchFile(options.style, { persistent: true,  interval: 100 }, function () {
         console.log('Rebuilding: ' + new Date());
-        createAndSave([file], options);
-        console.log('Notifying live reload.');
-        tinylr.changed(file);
+        createAndSave([file], options, function() {
+          tinylr.changed(file);
+        });
       });
     }
 

--- a/bin/cleaver
+++ b/bin/cleaver
@@ -68,6 +68,7 @@ program
   .action(function () {
     var file = program.args[0];
     var options = getOptions();
+    options.watch = true;
     createAndSave([file], options);
 
     var port = 35729;

--- a/bin/cleaver
+++ b/bin/cleaver
@@ -12,7 +12,11 @@ var Cleaver = require('../');
  * Helper function to use the cleaver API to create and save a new
  * presentation
  */
-function createAndSave(files, options) {
+function createAndSave(files, options, done) {
+  if (!done) {
+    done = function(){};
+  }
+
   files.forEach(function (file) {
     fs.readFile(file, 'utf-8', function (err, contents) {
       if (err) {
@@ -25,6 +29,7 @@ function createAndSave(files, options) {
         .then(function (product) {
           var outputFile = presentation.options.output || path.basename(file, '.md') + '-cleaver.html';
           fs.writeFile(outputFile, product);
+          done();
         })
         .fail(function (err) {
           process.stderr.write('!! ' + err.message + '\n');
@@ -94,6 +99,14 @@ program
         tinylr.changed(file);
       });
     }
+
+    process.on('SIGINT', function () {
+      console.log('\nRebuilding without watch mode: ' + new Date());
+      options.watch = false;
+      createAndSave([file], options, function() {
+        process.exit();
+      });
+    });
   });
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "js-yaml": "2.1.0",
     "marked": "~0.2.9",
     "mustache": "0.7.0",
-    "q": "0.9.6"
+    "q": "0.9.6",
+    "tiny-lr": "^0.2.1"
   },
   "devDependencies": {
     "jshint": "~2.3.0"

--- a/resources/script.js
+++ b/resources/script.js
@@ -35,8 +35,7 @@ function navigate(n) {
 function updateURL() {
   try {
     window.history.replaceState({} , null, '#' + currentPosition());
-  }
-  catch (e) {
+  } catch (e) {
     window.location.hash = currentPosition();
   }
 }

--- a/resources/script.js
+++ b/resources/script.js
@@ -33,7 +33,12 @@ function navigate(n) {
  * Updates the current URL to include a hashtag of the current page number.
  */
 function updateURL() {
-  window.history.replaceState({} , null, '#' + currentPosition());
+  try {
+    window.history.replaceState({} , null, '#' + currentPosition());
+  }
+  catch (e) {
+    window.location.hash = currentPosition();
+  }
 }
 
 

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -7,6 +7,7 @@
   <style type="text/css">
     {{{style}}}
   </style>
+  <script async src="http://localhost:35729/livereload.js"></script>
 </head>
 <body>
   {{{slideshow}}}

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -8,7 +8,7 @@
     {{{style}}}
   </style>
   {{#options.watch}}
-  <script async src="http://localhost:35729/livereload.js"></script>
+    <script async src="http://localhost:35729/livereload.js"></script>
   {{/options.watch}}
 </head>
 <body>

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -7,7 +7,9 @@
   <style type="text/css">
     {{{style}}}
   </style>
+  {{#options.watch}}
   <script async src="http://localhost:35729/livereload.js"></script>
+  {{/options.watch}}
 </head>
 <body>
   {{{slideshow}}}


### PR DESCRIPTION
This implements Live Reload using https://github.com/mklabs/tiny-lr.

The fallback to `replaceState` was introduced because in Chrome>45 `replaceState` is not allowed in the `file://` protocol. Discussion: https://code.google.com/p/chromium/issues/detail?id=529313

The live reload script is only introduced in `watch` mode. 

When exiting with `SIGINT` (<kbd>CTRL</kbd>+<kbd>C</kbd>), a last rebuild will be issued without the live reload script.

PS:
Thanks for the excellent framework. :)
The code is very good, it was a breeze to contribute to. :+1:  