### PR TITLE
move the progress bar above the slide content (z-index)

### DIFF
--- a/resources/default.css
+++ b/resources/default.css
@@ -132,6 +132,7 @@ pre {
   position: fixed;
   top: 0; left: 0; right: 0;
   height: 3px;
+  z-index: 1;
 }
 
 .progress-bar {


### PR DESCRIPTION
Added `z-index: 1` to move the progress bar above the slide content. The default theme places a background color on the slide, so the progress bar not visible.