### PR TITLE
added support for '---'-command

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,12 @@ Cleaver.prototype.renderSlideshow = function () {
  * @return {string} The formatted slide
  */
 Cleaver.prototype.renderSlide = function (content) {
-  return marked(content);
+  var cuts = content.split('\n---\n');
+  var rendered = cuts.map(function(text){return marked(text);});
+  if (rendered.length == 1)
+    return rendered[0]
+  else
+    return rendered.map(function(text){return '<section>'+text+'</section>';}).join('\n');
 };
 
 
@@ -294,7 +299,7 @@ Cleaver.prototype.renderAuthorSlide = function (content) {
  * @return {Array.<string>} A list of all slides
  */
 Cleaver.prototype.slice = function(document) {
-  var cuts = document.split(/\n(?=\-\-)/);
+  var cuts = document.split(/\n(?=\-\-\n)/);
   var slices = [];
   var nlIndex;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,11 +109,13 @@ Cleaver.prototype.renderSlides = function () {
   debug('parsed options');
 
   for (i = 1; i < slices.length; i++) {
+    var renderedSlides = this.renderSlide(slices[i].content)
     this.slides.push({
       id: i,
       hidden: i !== 1,  // first slide is visible
       classList: slices[i].classList,
-      content: this.renderSlide(slices[i].content)
+      content: renderedSlides.length === 1 ? renderedSlides[0] : null,
+      subslides: renderedSlides.length !== 1 ? renderedSlides.map(function(slideContent){return {content: slideContent};}) : null
     });
   }
 
@@ -274,10 +276,7 @@ Cleaver.prototype.renderSlideshow = function () {
 Cleaver.prototype.renderSlide = function (content) {
   var cuts = content.split('\n---\n');
   var rendered = cuts.map(function(text){return marked(text);});
-  if (rendered.length == 1)
-    return rendered[0]
-  else
-    return rendered.map(function(text){return '<section>'+text+'</section>';}).join('\n');
+  return rendered;
 };
 
 


### PR DESCRIPTION
The '---'-command allows to add additional sub-'<section>'-elements that come in handy with the http://github.com/sudodoki/reveal-cleaver-theme
Simply add, instead of '--', '---' and get a section under a section!
