### PR TITLE
Adding generator meta tag to provide version feedback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var hljs = require('highlight.js');
 var yaml = require('js-yaml');
 var mustache = require('mustache');
 
+var version = require('../package.json').version;
 var clone = require('./clone');
 var helper;
 var debugInited = false;
@@ -248,6 +249,7 @@ Cleaver.prototype.renderSlideshow = function () {
 
   var layoutData = {
     slideshow: slideshow,
+    version: version,
     title: title,
     encoding: encoding,
     style: style,

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="{{encoding}}">
+  {{#version}}<meta name="generator" content="cleaver {{version}}" />{{/version}}
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <title>{{title}}</title>
   <style type="text/css">


### PR DESCRIPTION
Might be helpful for
1) troubleshooting some issues
2) following the spread of cleaver over internet :D
3) indicating which version of cleaver to rollback to in case current version yields different output than expected

The way it's done means that each theme would need to output `{{version}}` thingy on their own.

Using `generator` name from [spec](https://www.w3.org/TR/html5/document-metadata.html#attr-meta-name) for this.