### PR TITLE
Have author.mustache be provided by theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ theme containing each of these assets. More specifically, a theme may contain:
 * template.mustache - a template used to render the slides in your presentation
 * layout.mustache - a template used to render the entire document of your
 presentation
+* author.mustache – a template used to render final slide with author details in your presentation
 * script.js - javascript to be included in your slideshow
 
 A theme does not need to contain all of these files, only the ones present

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -148,6 +148,7 @@ function loadTheme(source, ctx) {
     populateSingle(source + 'style.css', ctx.external, 'style'),
     populateSingle(source + 'template.mustache', ctx.templates, 'slides'),
     populateSingle(source + 'layout.mustache', ctx.templates, 'layout'),
+    populateSingle(source + 'author.mustache', ctx.templates, 'author'),
     populateSingle(source + 'script.js', ctx.external, 'script')
   ];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,21 +118,6 @@ Cleaver.prototype.renderSlides = function () {
     });
   }
 
-  // insert an author slide (if necessary) at the end
-  if (this.options.author) {
-    var twitter = this.options.author.twitter;
-    if (twitter && !twitter.match(/^@/)) {
-      this.options.author.twitter = '@' + this.options.author.twitter;
-    }
-
-    this.slides.push({
-      id: i,
-      hidden: true,
-      classList: 'author-slide',
-      content: this.renderAuthorSlide(this.options.author)
-    });
-  }
-
   return Q.resolve(true);
 };
 
@@ -213,6 +198,21 @@ Cleaver.prototype.renderSlideshow = function () {
   var putControls = this.options.controls || (this.options.controls === undefined);
   var putProgress = this.options.progress || (this.options.progress === undefined);
   var style, script, output;
+
+  // insert an author slide (if necessary) at the end (need to have theme loaded first)
+  if (this.options.author) {
+    var twitter = this.options.author.twitter;
+    if (twitter && !twitter.match(/^@/)) {
+      this.options.author.twitter = '@' + this.options.author.twitter;
+    }
+
+    this.slides.push({
+      id: this.slides.length,
+      hidden: true,
+      classList: 'author-slide',
+      content: this.renderAuthorSlide(this.options.author)
+    });
+  }
 
   // Render the slides in a template (maybe as specified by the user)
   var slideshow = mustache.render(this.templates.loaded.slides, {


### PR DESCRIPTION
Requested in #129. Required minor rearrangement of author rendering code as previously it was rendered before theme was loaded.
WIP: needs some additional documentation changes and possibly, having this logic incapsulated in `renderAuthorSlide`?