### PR TITLE
Support multiple files with styles

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -69,6 +69,13 @@ function populateSingle(filename, destination, key) {
     });
 }
 
+function populateMultiply(filenames, destination, key) {
+  filenames = filenames.split(',').map(filename => filename.trim());
+  var promises = filenames.map((filename) => {
+    return populateSingle(filename, destination, key);
+  });
+  return Q.all(promises);
+}
 
 /**
  * Loads files from a given map and places them in that map's `loaded` field
@@ -291,8 +298,8 @@ module.exports = function (inputPath, shouldDebug) {
   };
 
   return {
-    loadSingle: loadSingle,
     populateSingle: populateSingle,
+    populateMultiply: populateMultiply,
     load: load,
     loadTheme: loadTheme
   };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -70,8 +70,10 @@ function populateSingle(filename, destination, key) {
 }
 
 function populateMultiply(filenames, destination, key) {
-  filenames = filenames.split(',').map(filename => filename.trim());
-  var promises = filenames.map((filename) => {
+  filenames = filenames.split(',').map(function (filename) {
+    return filename.trim();
+  });
+  var promises = filenames.map(function (filename) {
     return populateSingle(filename, destination, key);
   });
   return Q.all(promises);

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,7 @@ Cleaver.prototype.populateResources = function () {
 
   // maybe load an external stylesheet
   if (this.options.style) {
-    promises.push(helper.populateSingle(this.options.style, this.external, 'style')
+    promises.push(helper.populateMultiply(this.options.style, this.external, 'style')
       .then(function () {
         debug('loaded user stylesheet');
       }));


### PR DESCRIPTION
Today I have problem to how add my second custom style for printers.

So I would like to have two files:
- main.css - for screens
- print.css - for printers

We should be able to support multiple files with stylesheet definition.

@jdan What do you think about this problem (and solution)?
