### PR TITLE
options.json not recognized, but settings.json is?

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Themes may be specified by one of the following options:
 By default, *style.css* and *script.js* will be **appended** to the default
 stylesheets and javascripts included in cleaver presentations. If you wish to
 completely override these defaults, you must include another file in your
-theme - options.json - corresponding to the following:
+theme - settings.json - corresponding to the following:
 
 ```json
 {


### PR DESCRIPTION
The override setting wasn't picked up until I renamed the file from options.json to settings.json