### PR TITLE
Pass options to slide template rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -258,7 +258,7 @@ Cleaver.prototype.renderSlideshow = function () {
     style: style,
     author: this.options.author,
     script: script,
-    options: this.options
+    options: options
   };
 
   /* Return the rendered slideshow */

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,11 +212,14 @@ Cleaver.prototype.loadStaticAssets = function () {
 Cleaver.prototype.renderSlideshow = function () {
   var putControls = this.options.controls || (this.options.controls === undefined);
   var putProgress = this.options.progress || (this.options.progress === undefined);
+  var options = Object.assign({}, this.options, { controls: putControls, progress: putProgress });
+
   var style, script, output;
 
   // Render the slides in a template (maybe as specified by the user)
   var slideshow = mustache.render(this.templates.loaded.slides, {
     slides: this.slides,
+    options: options,
     controls: putControls,
     progress: putProgress
   });

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,8 +1,8 @@
-{{#progress}}
+{{#options.progress}}
   <div class="progress">
     <div class="progress-bar"></div>
   </div>
-{{/progress}}
+{{/options.progress}}
 
 {{#slides}}
   <div class="slide{{#hidden}} hidden{{/hidden}}{{#classList}} {{classList}}{{/classList}}" id="slide-{{id}}">
@@ -10,9 +10,9 @@
   </div>
 {{/slides}}
 
-{{#controls}}
+{{#options.controls}}
   <div class="controls">
     <div class="arrow prev"></div>
     <div class="arrow next"></div>
   </div>
-{{/controls}}
+{{/options.controls}}


### PR DESCRIPTION
This passes the `options` down to the slide template, so it's easier to extend it with new (customisable) functionality. Right now only the _layout_ has access to the options, limiting where you can place new elements.

Additionally made sure that the default values for `options.controls` and `options.progress` are properly passed down (i.e. `true` when not defined explicitly) to _layout_ as well.

It might make sense to remove the passing down of `controls` and `progress` to the slide template as well, but I figured leaving it in is a bit better for backwards-compatibility.