### PR TITLE
Use markdown-it instead of marked

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,6 +62,7 @@ function Cleaver(document, options, includePath) {
   this.override = false;
 
   this.md = markdownIt({
+    html: true,
     highlight: function (code, lang) {
       if (lang && hljs.getLanguage(lang)) {
         try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 var Q = require('q');
 var debug = require('debug');
 var path = require('path');
-var marked = require('marked');
+var markdownIt = require('markdown-it');
+var markdownItAttrs = require('markdown-it-attrs');
 var hljs = require('highlight.js');
 var yaml = require('js-yaml');
 var mustache = require('mustache');
@@ -60,8 +61,7 @@ function Cleaver(document, options, includePath) {
   this.slides = [];
   this.override = false;
 
-  marked.setOptions({
-    gfm: true,
+  this.md = markdownIt({
     highlight: function (code, lang) {
       try {
         return hljs.highlight(lang, code).value;
@@ -69,7 +69,8 @@ function Cleaver(document, options, includePath) {
         return code;
       }
     }
-  });
+  })
+    .use(markdownItAttrs);
 }
 
 
@@ -274,7 +275,7 @@ Cleaver.prototype.renderSlideshow = function () {
  * @return {string} The formatted slide
  */
 Cleaver.prototype.renderSlide = function (content) {
-  return marked(content);
+  return this.md.render(content);
 };
 
 
@@ -295,7 +296,7 @@ Cleaver.prototype.renderAuthorSlide = function (content) {
  * @param {string} The full document
  * @return {Array.<string>} A list of all slides
  */
-Cleaver.prototype.slice = function(document) {
+Cleaver.prototype.slice = function (document) {
   var cuts = document.split(/\n(?=\-\-)/);
   var slices = [];
   var nlIndex;

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,11 +63,13 @@ function Cleaver(document, options, includePath) {
 
   this.md = markdownIt({
     highlight: function (code, lang) {
-      try {
-        return hljs.highlight(lang, code).value;
-      } catch (e) {
-        return code;
+      if (lang && hljs.getLanguage(lang)) {
+        try {
+          return hljs.highlight(code, { language: lang }).value;
+        } catch (__) { }
       }
+
+      return ''; // use external default escaping
     }
   })
     .use(markdownItAttrs);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "version": "0.8.6",
   "author": "Jordan Scales <scalesjordan@gmail.com>",
   "description": "30-second slideshows for hackers",
-  "keywords": ["markdown", "static", "slideshow", "presentation"],
+  "keywords": [
+    "markdown",
+    "static",
+    "slideshow",
+    "presentation"
+  ],
   "bin": {
     "cleaver": "./bin/cleaver"
   },
@@ -18,7 +23,8 @@
     "debug": "^3.1.0",
     "highlight.js": "~9.12.0",
     "js-yaml": "3.10.0",
-    "marked": "^0.3.7",
+    "markdown-it": "^12.2.0",
+    "markdown-it-attrs": "^4.1.0",
     "mustache": "^2.3.0",
     "q": "1.5.1",
     "tiny-lr": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "commander": "~2.12.2",
     "debug": "^3.1.0",
-    "highlight.js": "~9.12.0",
+    "highlight.js": "^11.3.1",
     "js-yaml": "3.10.0",
     "markdown-it": "^12.2.0",
     "markdown-it-attrs": "^4.1.0",


### PR DESCRIPTION
I know this is an opinionated PR, but, I propose to replace the renderer from [`marked`](https://github.com/markedjs/marked) to [`markdown-it`](https://github.com/markdown-it/markdown-it).

**Why?**

* markdown-it is the second most-popular JS Markdown renderer (see [here](https://www.npmtrends.com/markdown-it-vs-marked-vs-remarkable-vs-showdown))
* markdown-it provides more features and easy extendibility via community-written plugins  (see [here](https://github.com/markdown-it/markdown-it))
* One useful plugin in particular would be [`markdown-it-attrs`](https://github.com/arve0/markdown-it-attrs) which allows one to add CSS classes, HTML attributes and identifiers to any Markdown element with [this](https://pandoc.org/MANUAL.html#extension-header_attributes) syntax: `{.class #identifier attr=value attr2="spaced value"}`
* Could resolve #111 by adding `{.fragment}` class attributes along with scripts and styles (similar to [`cleaver-select-theme`](https://github.com/select/cleaver-select-theme) but without the need for explicit HTML)
* Could resolve #170 by adding [`markdown-it-mathjax`](https://github.com/classeur/markdown-it-mathjax)
* Could resolve #102 by adding [`markdown-it-emoji`](https://github.com/markdown-it/markdown-it-emoji)

**Implications?**

* The change is quite straight-forward, see attached code diff
* Shouldn't break existing presentations because markdown-it should be a superset to marked
* I also bumped the version of highlight.js in this PR just because I thought it would make sense as well
